### PR TITLE
Fix crash when boots cannot be listed

### DIFF
--- a/manalog/manalog
+++ b/manalog/manalog
@@ -63,9 +63,10 @@ class MlDialog(basedialog.BaseDialog):
   def listBoots(self) :
     boots = []
     status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --list-boots -q")
-    lines = text.split("\n")
-    boot_re = re.compile("(?P<order>[+-]?[0-9]+) (?P<bootid>[0-9A-Za-z]+) [A-Za-z]+ (?P<start>(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])? [A-Za-z]+)—[A-Za-z]+ (?P<end>(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])? [A-Za-z]+)")
-    for line in lines :
+    if status == 0 :
+      lines = text.split("\n")
+      boot_re = re.compile("(?P<order>[+-]?[0-9]+) (?P<bootid>[0-9A-Za-z]+) [A-Za-z]+ (?P<start>(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])? [A-Za-z]+)—[A-Za-z]+ (?P<end>(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9]) (2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])? [A-Za-z]+)")
+      for line in lines :
         res = boot_re.search(line)
         boots.append([res.group('order'), res.group('bootid'), res.group('start'), res.group('end')])
     return boots

--- a/manalog/manalog
+++ b/manalog/manalog
@@ -161,6 +161,10 @@ class MlDialog(basedialog.BaseDialog):
         self.bootModel[key] = boot[1]    #  boot_id
         item.this.own(False)
         dlist.append(item)
+    if not dlist :
+      wd = common.warningMsgBox({'title' : _("Boots cannot be listed"),
+                                 'text' : _("Failed to determine boots: No data available.\nVerify the system journal."),
+                                 'richtext' : True})
     itemCollection = yui.YItemCollection(dlist)
     self.boots.addItems(itemCollection)
     yui.YUI.app().normalCursor()


### PR DESCRIPTION
Fix the crash that happens when journalctl cannot list boots because of corrupted system journal.

Moreover, a warning box is added in order to warn the user that his system journal is corrupted. The warning box has the same error message as _journalctl --list-boots_.