### PR TITLE
Add journal verification option

### DIFF
--- a/manalog/manalog
+++ b/manalog/manalog
@@ -449,9 +449,18 @@ class MlDialog(basedialog.BaseDialog):
   def onVerify(self) :
     yui.YUI.app().busyCursor()
     status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+    if status == -1 :
+      lines = text.splitlines(keepends = True)
+      textToShow = ""
+      for element in lines :
+        if "FAIL" in element:
+          textToShow += element
+    else :
+      textToShow = _("No errors have been detected in journal files.")
+    yui.YUI.app().normalCursor()
     ok = common.msgBox({
       'title' : _("ManaLog - Verify journal"),
-      'text' : text,
+      'text' : textToShow,
       'richText' : True,
       })
   

--- a/manalog/manalog
+++ b/manalog/manalog
@@ -237,6 +237,8 @@ class MlDialog(basedialog.BaseDialog):
     self.eventManager.addWidgetEvent(aboutButton, self.onAbout)
     align = self.factory.createRight(hbox)
     hbox     = self.factory.createHBox(align)
+    verifyButton = self.factory.createPushButton(hbox, _("&Verify"))
+    self.eventManager.addWidgetEvent(verifyButton, self.onVerify)
     saveButton = self.factory.createPushButton(hbox, _("&Save"))
     self.eventManager.addWidgetEvent(saveButton, self._save)
     quitButton = self.factory.createPushButton(hbox, _("&Quit"))
@@ -444,6 +446,15 @@ class MlDialog(basedialog.BaseDialog):
             'description' : _("Log viewer is a systemd journal viewer"),
       })
 
+  def onVerify(self) :
+    yui.YUI.app().busyCursor()
+    status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+    ok = common.msgBox({
+      'title' : _("ManaLog - Verify journal"),
+      'text' : text,
+      'richText' : True,
+      })
+  
   def _save(self) :
        yui.YUI.app().busyCursor()
        save_name = yui.YUI.app().askForSaveFileName(os.path.expanduser("~"), "*", _("Save as.."))


### PR DESCRIPTION
Add a button to verify journal files. It is a front-end to _journalctl --verify_ command. 
When starting manaLog, the user can be warned about corrupted journal files. Now, he can check his journal. 
The result is a message box with a message if no errors have been detected or the list of files that do not pass the verification. 
 This _journalctl_ command takes some time to complete (1-2 minutes) so the user have to be patient.
I checked in Virtual Machine that the output status of _journalctl_ is 0 if all files pass the test and 1 if one or more files fail the test.