### PR TITLE
Change verification of journal when listing boots fails.

### DIFF
--- a/manalog/manalog
+++ b/manalog/manalog
@@ -29,7 +29,7 @@ import gettext
 from datetime import date, datetime
 from systemd import journal
 import os, select, subprocess
-import re
+from re import search, match
 import operator
 
 ######################################################################
@@ -40,6 +40,7 @@ import operator
 
 class MlDialog(basedialog.BaseDialog):
   def __init__(self):
+
     if os.getuid() == 0 :
         space = _("System space")
     else :
@@ -173,10 +174,39 @@ class MlDialog(basedialog.BaseDialog):
         self.bootModel[key] = boot[1]    #  boot_id
         item.this.own(False)
         dlist.append(item)
+
     if not dlist :
-      wd = common.warningMsgBox({'title' : _("Boots cannot be listed"),
-                                 'text' : _("Failed to determine boots: No data available.\nVerify the system journal."),
-                                 'richtext' : True})
+      # Display error message and ask for journal verification when boots cannot be listed.
+      if common.askYesOrNo({'title' : _("Boots cannot be listed"),
+                            'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
+                            'richtext' : True,
+                            'default_button' : 2}) == True :
+        status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+        if status != 0 :
+          textToShow = ""
+          failedFiles= ""
+          for element in text.splitlines(keepends = True) :
+            if "FAIL" in element:
+              failedFiles += element
+          textToShow += failedFiles
+          if os.getuid() == 0 :
+            textToShow += _("\nDo you want to remove these files ?")
+            if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
+                                  'text' : textToShow,
+                                  'richText' : True,
+                                  'default_button' : 2}) == True :
+              for element in failedFiles.splitlines(keepends = False) :
+                os.remove(search('\s(.+?)\s', element).group(1))
+          else :
+            textToShow += _("\nYou must be root to remove these files.")
+            common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
+                                   'text' : textToShow,
+                                   'richtext' : True})
+        else :
+          common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
+                             'text' : _("No errors have been detected in journal files."),
+                             'richtext' : True})
+        
     itemCollection = yui.YItemCollection(dlist)
     self.boots.addItems(itemCollection)
     yui.YUI.app().normalCursor()
@@ -249,8 +279,6 @@ class MlDialog(basedialog.BaseDialog):
     self.eventManager.addWidgetEvent(aboutButton, self.onAbout)
     align = self.factory.createRight(hbox)
     hbox     = self.factory.createHBox(align)
-    verifyButton = self.factory.createPushButton(hbox, _("&Verify"))
-    self.eventManager.addWidgetEvent(verifyButton, self.onVerify)
     saveButton = self.factory.createPushButton(hbox, _("&Save"))
     self.eventManager.addWidgetEvent(saveButton, self._save)
     quitButton = self.factory.createPushButton(hbox, _("&Quit"))
@@ -456,24 +484,6 @@ class MlDialog(basedialog.BaseDialog):
             'license' : 'GPLv3',
             'authors' : 'Papoteur &lt;papoteur@mageialinux-online.org&gt;',
             'description' : _("Log viewer is a systemd journal viewer"),
-      })
-
-  def onVerify(self) :
-    yui.YUI.app().busyCursor()
-    status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
-    if status == -1 :
-      lines = text.splitlines(keepends = True)
-      textToShow = ""
-      for element in lines :
-        if "FAIL" in element:
-          textToShow += element
-    else :
-      textToShow = _("No errors have been detected in journal files.")
-    yui.YUI.app().normalCursor()
-    ok = common.msgBox({
-      'title' : _("ManaLog - Verify journal"),
-      'text' : textToShow,
-      'richText' : True,
       })
   
   def _save(self) :

--- a/manalog/manalog
+++ b/manalog/manalog
@@ -174,7 +174,7 @@ class MlDialog(basedialog.BaseDialog):
     self.bootsFrame = self.factory.createCheckBoxFrame(hbox,_("Select a boot"), True)
     self.bootsFrame.setNotify(True)
     if dlist == [] :
-      self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameErrorEvent)
+        self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameErrorEvent)
     else :
       self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameEvent)      
     self.boots = self.factory.createComboBox( self.factory.createLeft(self.bootsFrame), "" )
@@ -441,39 +441,41 @@ class MlDialog(basedialog.BaseDialog):
   def onBootFrameErrorEvent(self):
     # Display error message and ask for journal verification when boots cannot be listed.
     yui.YUI.ui().blockEvents()
-    yui.YUI.app().busyCursor()
-    if common.askYesOrNo({'title' : _("Boots cannot be listed"),
-                          'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
-                          'richtext' : True,
-                          'default_button' : 2}) == True :
-      status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
-      yui.YUI.app().normalCursor()
-      if status != 0 :
-        textToShow = ""
-        failedFiles= ""
-        for element in text.splitlines(keepends = True) :
-          if "FAIL" in element:
-            failedFiles += element
-            textToShow += failedFiles
-        if os.getuid() == 0 :
-          textToShow += _("\nDo you want to remove these files ?")
-          if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
-                                'text' : textToShow,
-                                'richText' : True,
-                                'default_button' : 2}) == True :
-            for element in failedFiles.splitlines(keepends = False) :
-              os.remove(search('\s(.+?)\s', element).group(1))
+    if self.bootsFrame.value() :
+      yui.YUI.app().busyCursor()
+      if common.askYesOrNo({'title' : _("Boots cannot be listed"),
+                            'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
+                            'richtext' : True,
+                            'default_button' : 2}) == True :
+        status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+        yui.YUI.app().normalCursor()
+        if status != 0 :
+          textToShow = ""
+          failedFiles= ""
+          for element in text.splitlines(keepends = True) :
+            if "FAIL" in element:
+              failedFiles += element
+              textToShow += failedFiles
+          if os.getuid() == 0 :
+            textToShow += _("\nDo you want to remove these files ?")
+            if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
+                                  'text' : textToShow,
+                                  'richText' : True,
+                                  'default_button' : 2}) == True :
+              for element in failedFiles.splitlines(keepends = False) :
+                os.remove(search('\s(.+?)\s', element).group(1))
+          else :
+            textToShow += _("\nYou must be root to remove these files.")
+            common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
+                                   'text' : textToShow,
+                                   'richtext' : True})
         else :
-          textToShow += _("\nYou must be root to remove these files.")
-          common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
-                                 'text' : textToShow,
-                                 'richtext' : True})
+          common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
+                             'text' : _("No errors have been detected in journal files."),
+                             'richtext' : True})
       else :
-        common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
-                           'text' : _("No errors have been detected in journal files."),
-                           'richtext' : True})
-    else :
-      yui.YUI.app().normalCursor()
+        yui.YUI.app().normalCursor()
+    self.bootsFrame.setValue(False)
     yui.YUI.ui().unblockEvents()
     
   def onCancelEvent(self) :

--- a/manalog/manalog
+++ b/manalog/manalog
@@ -170,7 +170,6 @@ class MlDialog(basedialog.BaseDialog):
         self.bootModel[key] = boot[1]    #  boot_id
         item.this.own(False)
         dlist.append(item)
-    dlist = [] # For testing purpose
     self.bootsFrame = self.factory.createCheckBoxFrame(hbox,_("Select a boot"), True)
     self.bootsFrame.setNotify(True)
     if dlist == [] :
@@ -392,6 +391,46 @@ class MlDialog(basedialog.BaseDialog):
           self.lastBoot.setValue(False)
       yui.YUI.ui().unblockEvents()
 
+  def onBootFrameErrorEvent(self):
+    # Display error message and ask for journal verification when boots cannot be listed.
+    yui.YUI.ui().blockEvents()
+    if self.bootsFrame.value() :
+      yui.YUI.app().busyCursor()
+      if common.askYesOrNo({'title' : _("Boots cannot be listed"),
+                            'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
+                            'richtext' : True,
+                            'default_button' : 2}) == True :
+        status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+        yui.YUI.app().normalCursor()
+        if status != 0 :
+          textToShow = ""
+          failedFiles= ""
+          for element in text.splitlines(keepends = True) :
+            if "FAIL" in element:
+              failedFiles += element
+              textToShow += failedFiles
+          if os.getuid() == 0 :
+            textToShow += _("\nDo you want to remove these files ?")
+            if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
+                                  'text' : textToShow,
+                                  'richText' : True,
+                                  'default_button' : 2}) == True :
+              for element in failedFiles.splitlines(keepends = False) :
+                os.remove(search('\s(.+?)\s', element).group(1))
+          else :
+            textToShow += _("\nYou must be root to remove these files.")
+            common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
+                                   'text' : textToShow,
+                                   'richtext' : True})
+        else :
+          common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
+                             'text' : _("No errors have been detected in journal files."),
+                             'richtext' : True})
+      else :
+        yui.YUI.app().normalCursor()
+    self.bootsFrame.setValue(False)
+    yui.YUI.ui().unblockEvents()
+
   def onSinceFrameEvent(self) :
       yui.YUI.ui().blockEvents()
       if self.sinceFrame.value() :
@@ -437,46 +476,6 @@ class MlDialog(basedialog.BaseDialog):
            self.lastBoot.setEnabled()
            
       yui.YUI.ui().unblockEvents()
-
-  def onBootFrameErrorEvent(self):
-    # Display error message and ask for journal verification when boots cannot be listed.
-    yui.YUI.ui().blockEvents()
-    if self.bootsFrame.value() :
-      yui.YUI.app().busyCursor()
-      if common.askYesOrNo({'title' : _("Boots cannot be listed"),
-                            'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
-                            'richtext' : True,
-                            'default_button' : 2}) == True :
-        status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
-        yui.YUI.app().normalCursor()
-        if status != 0 :
-          textToShow = ""
-          failedFiles= ""
-          for element in text.splitlines(keepends = True) :
-            if "FAIL" in element:
-              failedFiles += element
-              textToShow += failedFiles
-          if os.getuid() == 0 :
-            textToShow += _("\nDo you want to remove these files ?")
-            if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
-                                  'text' : textToShow,
-                                  'richText' : True,
-                                  'default_button' : 2}) == True :
-              for element in failedFiles.splitlines(keepends = False) :
-                os.remove(search('\s(.+?)\s', element).group(1))
-          else :
-            textToShow += _("\nYou must be root to remove these files.")
-            common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
-                                   'text' : textToShow,
-                                   'richtext' : True})
-        else :
-          common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
-                             'text' : _("No errors have been detected in journal files."),
-                             'richtext' : True})
-      else :
-        yui.YUI.app().normalCursor()
-    self.bootsFrame.setValue(False)
-    yui.YUI.ui().unblockEvents()
     
   def onCancelEvent(self) :
     print ("Got a cancel event")

--- a/manalog/manalog
+++ b/manalog/manalog
@@ -162,10 +162,6 @@ class MlDialog(basedialog.BaseDialog):
     itemCollection = yui.YItemCollection(dlist)
     self.units.addItems(itemCollection)
     #### boots
-    self.bootsFrame = self.factory.createCheckBoxFrame(hbox,_("Select a boot"), True)
-    self.bootsFrame.setNotify(True)
-    self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameEvent)
-    self.boots = self.factory.createComboBox( self.factory.createLeft(self.bootsFrame), "" )
     dlist = []
     self.bootModel = {}
     for boot in self.listBoots() :
@@ -174,43 +170,17 @@ class MlDialog(basedialog.BaseDialog):
         self.bootModel[key] = boot[1]    #  boot_id
         item.this.own(False)
         dlist.append(item)
-
-    if not dlist :
-      # Display error message and ask for journal verification when boots cannot be listed.
-      if common.askYesOrNo({'title' : _("Boots cannot be listed"),
-                            'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
-                            'richtext' : True,
-                            'default_button' : 2}) == True :
-        status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
-        if status != 0 :
-          textToShow = ""
-          failedFiles= ""
-          for element in text.splitlines(keepends = True) :
-            if "FAIL" in element:
-              failedFiles += element
-          textToShow += failedFiles
-          if os.getuid() == 0 :
-            textToShow += _("\nDo you want to remove these files ?")
-            if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
-                                  'text' : textToShow,
-                                  'richText' : True,
-                                  'default_button' : 2}) == True :
-              for element in failedFiles.splitlines(keepends = False) :
-                os.remove(search('\s(.+?)\s', element).group(1))
-          else :
-            textToShow += _("\nYou must be root to remove these files.")
-            common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
-                                   'text' : textToShow,
-                                   'richtext' : True})
-        else :
-          common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
-                             'text' : _("No errors have been detected in journal files."),
-                             'richtext' : True})
-        
+    dlist = [] # For testing purpose
+    self.bootsFrame = self.factory.createCheckBoxFrame(hbox,_("Select a boot"), True)
+    self.bootsFrame.setNotify(True)
+    if dlist == [] :
+      self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameErrorEvent)
+    else :
+      self.eventManager.addWidgetEvent(self.bootsFrame, self.onBootFrameEvent)      
+    self.boots = self.factory.createComboBox( self.factory.createLeft(self.bootsFrame), "" )
     itemCollection = yui.YItemCollection(dlist)
     self.boots.addItems(itemCollection)
-    yui.YUI.app().normalCursor()
-
+    
     #### priority
     # From
     self.factory.createHSpacing(row2, 2.0)
@@ -286,8 +256,9 @@ class MlDialog(basedialog.BaseDialog):
 
     # Let's test a cancel event
     self.eventManager.addCancelEvent(self.onCancelEvent)
- 
+    
     # End Dialof layout
+    
 
   def onStopButton(self): 
     print ('Button "Stop" pressed')
@@ -467,6 +438,44 @@ class MlDialog(basedialog.BaseDialog):
            
       yui.YUI.ui().unblockEvents()
 
+  def onBootFrameErrorEvent(self):
+    # Display error message and ask for journal verification when boots cannot be listed.
+    yui.YUI.ui().blockEvents()
+    yui.YUI.app().busyCursor()
+    if common.askYesOrNo({'title' : _("Boots cannot be listed"),
+                          'text' : _("Failed to determine boots: No data available. Do you want to verify the system journal ? (this can take a while)"),
+                          'richtext' : True,
+                          'default_button' : 2}) == True :
+      status,text = self.commands_getstatusoutput("LC_ALL=C journalctl --verify -q")
+      yui.YUI.app().normalCursor()
+      if status != 0 :
+        textToShow = ""
+        failedFiles= ""
+        for element in text.splitlines(keepends = True) :
+          if "FAIL" in element:
+            failedFiles += element
+            textToShow += failedFiles
+        if os.getuid() == 0 :
+          textToShow += _("\nDo you want to remove these files ?")
+          if common.askYesOrNo({'title' : _("ManaLog - Verify journal"),
+                                'text' : textToShow,
+                                'richText' : True,
+                                'default_button' : 2}) == True :
+            for element in failedFiles.splitlines(keepends = False) :
+              os.remove(search('\s(.+?)\s', element).group(1))
+        else :
+          textToShow += _("\nYou must be root to remove these files.")
+          common.warningMsgBox ({'title' : _("ManaLog - Verify journal"),
+                                 'text' : textToShow,
+                                 'richtext' : True})
+      else :
+        common.infoMsgBox({'title' : _("ManaLog - Verify journal"),
+                           'text' : _("No errors have been detected in journal files."),
+                           'richtext' : True})
+    else :
+      yui.YUI.app().normalCursor()
+    yui.YUI.ui().unblockEvents()
+    
   def onCancelEvent(self) :
     print ("Got a cancel event")
 
@@ -492,6 +501,8 @@ class MlDialog(basedialog.BaseDialog):
        if save_name :
            with open(save_name, 'w') as fd:
                 fd.write(self.logView.logText())
+
+
       
 if __name__ == '__main__':
   gettext.install('manatools', localedir='/usr/share/locale', names=('ngettext',))


### PR DESCRIPTION
I've removed the "verify" button which was unclear. Now, when boots cannot be listed, manalog is launched as usual.
When the user try to list boots, if it is not possible, an error message is displayed. The user has the choice of doing verification or not. After verification, if the user is root, he can delete corrupted files. Otherwise, an error message is displayed. 
"journalctl --verify" is used yet. Journalctl code is too complicate for me to translate it into python. But I think It is important to have this posibility because:

1. Systemd journal is often corrupted (on my computer and on all of my VM it happens at least one time).
2. A non-exprimented user wouldn't use command line to verify is journal integrity.